### PR TITLE
Match wireframes better - dates and NO DATA

### DIFF
--- a/src/components/BeaconsTable.tsx
+++ b/src/components/BeaconsTable.tsx
@@ -25,7 +25,7 @@ import React, {
   useState,
 } from "react";
 import {
-  formatDate,
+  formatDateLong,
   formatUses,
   titleCase,
 } from "useCases/mcaWritingStyleFormatter";
@@ -93,7 +93,7 @@ export const BeaconsTable: FunctionComponent<IBeaconsTableProps> = ({
         const response = await beaconsGateway.getAllBeacons();
 
         const beacons = response.data.map((item: any) => ({
-          date: formatDate(item.attributes.createdDate),
+          date: formatDateLong(item.attributes.createdDate),
           status: titleCase(item.attributes.status),
           hexId: item.attributes.hexId,
           owner: item.attributes.owner.fullName,

--- a/src/components/dataPanel/FieldValue.tsx
+++ b/src/components/dataPanel/FieldValue.tsx
@@ -4,8 +4,14 @@ import { formatFieldValue } from "../../useCases/mcaWritingStyleFormatter";
 
 interface IFieldValueProps {
   children: string | undefined;
+  valueType?: FieldValueTypes;
+}
+
+export enum FieldValueTypes {
+  DATE = "DATE",
 }
 
 export const FieldValue: FunctionComponent<IFieldValueProps> = ({
   children,
-}) => <Typography>{formatFieldValue(children)}</Typography>;
+  valueType,
+}) => <Typography>{formatFieldValue(children, valueType)}</Typography>;

--- a/src/components/dataPanel/FieldValue.tsx
+++ b/src/components/dataPanel/FieldValue.tsx
@@ -9,6 +9,7 @@ interface IFieldValueProps {
 
 export enum FieldValueTypes {
   DATE = "DATE",
+  MULTILINE = "MULTILINE",
 }
 
 export const FieldValue: FunctionComponent<IFieldValueProps> = ({

--- a/src/components/dataPanel/PanelViewState.tsx
+++ b/src/components/dataPanel/PanelViewState.tsx
@@ -9,13 +9,14 @@ import {
 } from "@material-ui/core";
 import React, { FunctionComponent } from "react";
 import { WritingStyle } from "../../useCases/mcaWritingStyleFormatter";
-import { FieldValue } from "./FieldValue";
+import { FieldValue, FieldValueTypes } from "./FieldValue";
 
 type IFieldValue = string | undefined;
 
 export interface IField {
   key: string;
   value: IFieldValue | IFieldValue[];
+  valueType?: FieldValueTypes;
 }
 
 interface IPanelViewStateProps {
@@ -52,6 +53,7 @@ const OneColumn: FunctionComponent<IPanelViewStateProps> = ({ fields }) => (
     <Table size="small">
       <TableBody>
         {fields.map((field, index) => {
+          console.log(field.valueType);
           const valuesAsArray =
             field.value instanceof Array ? field.value : [field.value];
           return (
@@ -63,7 +65,9 @@ const OneColumn: FunctionComponent<IPanelViewStateProps> = ({ fields }) => (
               </TableCell>
               <TableCell>
                 {valuesAsArray.map((value, index) => (
-                  <FieldValue key={index}>{value}</FieldValue>
+                  <FieldValue key={index} valueType={field.valueType}>
+                    {value}
+                  </FieldValue>
                 ))}
               </TableCell>
             </TableRow>

--- a/src/panels/BeaconSummaryPanel.tsx
+++ b/src/panels/BeaconSummaryPanel.tsx
@@ -8,6 +8,7 @@ import {
 } from "@material-ui/core";
 import ErrorOutlineIcon from "@material-ui/icons/ErrorOutline";
 import React, { FunctionComponent, useEffect, useState } from "react";
+import { FieldValueTypes } from "../components/dataPanel/FieldValue";
 import {
   DataPanelStates,
   PanelViewState,
@@ -75,10 +76,12 @@ export const BeaconSummaryPanel: FunctionComponent<IBeaconSummaryProps> = ({
     {
       key: "Battery expiry date",
       value: beacon?.batteryExpiryDate,
+      valueType: FieldValueTypes.DATE,
     },
     {
       key: "Last serviced date",
       value: beacon?.lastServicedDate,
+      valueType: FieldValueTypes.DATE,
     },
     {
       key: "Owner(s)",

--- a/src/panels/EmergencyContactSummaryPanel.tsx
+++ b/src/panels/EmergencyContactSummaryPanel.tsx
@@ -1,6 +1,7 @@
 import { Card, CardContent, CardHeader } from "@material-ui/core";
 import { PanelViewState } from "components/dataPanel/PanelViewState";
 import React, { FunctionComponent, useEffect, useState } from "react";
+import { FieldValueTypes } from "../components/dataPanel/FieldValue";
 import { IEmergencyContact } from "../entities/IEmergencyContact";
 import { IBeaconsGateway } from "../gateways/IBeaconsGateway";
 
@@ -47,6 +48,7 @@ export const EmergencyContactSummaryPanel: FunctionComponent<EmergencyContactSum
         emergencyContact.telephoneNumber,
         emergencyContact.alternativeTelephoneNumber,
       ],
+      valueType: FieldValueTypes.MULTILINE,
     },
   ]);
 

--- a/src/panels/OwnerSummaryPanel.tsx
+++ b/src/panels/OwnerSummaryPanel.tsx
@@ -4,6 +4,7 @@ import {
   PanelViewState,
 } from "components/dataPanel/PanelViewState";
 import React, { FunctionComponent, useEffect, useState } from "react";
+import { FieldValueTypes } from "../components/dataPanel/FieldValue";
 import { IOwner } from "../entities/IOwner";
 import { IBeaconsGateway } from "../gateways/IBeaconsGateway";
 
@@ -55,6 +56,7 @@ export const OwnerSummaryPanel: FunctionComponent<OwnerSummaryPanelProps> = ({
         owner?.county,
         owner?.postcode,
       ],
+      valueType: FieldValueTypes.MULTILINE,
     },
   ];
 

--- a/src/useCases/mcaWritingStyleFormatter.test.tsx
+++ b/src/useCases/mcaWritingStyleFormatter.test.tsx
@@ -1,12 +1,16 @@
+import { FieldValueTypes } from "../components/dataPanel/FieldValue";
 import { Activities, Environments, Purposes } from "../entities/IUse";
 import {
-  formatDate,
+  formatDateLong,
+  formatDateShort,
+  formatFieldValue,
   formatOwners,
   formatUses,
+  Placeholders,
   titleCase,
 } from "./mcaWritingStyleFormatter";
 
-describe("formatDate()", () => {
+describe("formatDateLong()", () => {
   const expectations = [
     { in: "1 April 2021", out: "1 Apr 21" },
     { in: "1 April 2022", out: "1 Apr 22" },
@@ -17,7 +21,22 @@ describe("formatDate()", () => {
     it(`formats ${JSON.stringify(expectation.in)} ==> ${
       expectation.out
     }`, () => {
-      expect(formatDate(expectation.in)).toEqual(expectation.out);
+      expect(formatDateLong(expectation.in)).toEqual(expectation.out);
+    });
+  });
+});
+
+describe("formatDateShort()", () => {
+  const expectations = [
+    { in: "2020-02-01T00:00:00.000Z", out: "Feb 2020" },
+    { in: "2021-05-06T10:00:03.592854", out: "May 2021" },
+  ];
+
+  expectations.forEach((expectation) => {
+    it(`formats ${JSON.stringify(expectation.in)} ==> ${
+      expectation.out
+    }`, () => {
+      expect(formatDateShort(expectation.in)).toEqual(expectation.out);
     });
   });
 });
@@ -151,5 +170,27 @@ describe("formatOwners()", () => {
     it(`formats ${expectation.in} ==> ${expectation.out}`, () => {
       expect(formatOwners(expectation.in)).toEqual(expectation.out);
     });
+  });
+});
+
+describe("formatFieldValue()", () => {
+  const expectations = [
+    { in: undefined, out: <i>{Placeholders.NoData}</i> },
+    { in: "Beacons", out: <b>BEACONS</b> },
+    { in: "1234", out: <b>1234</b> },
+  ];
+
+  expectations.forEach((expectation) => {
+    it(`formats ${JSON.stringify(expectation.in)} ==> ${
+      expectation.out
+    }`, () => {
+      expect(formatFieldValue(expectation.in)).toEqual(expectation.out);
+    });
+  });
+
+  it("formats dates correctly", () => {
+    expect(
+      formatFieldValue("2021-05-06T10:00:04.285653", FieldValueTypes.DATE)
+    ).toEqual(<b>May 2021</b>);
   });
 });

--- a/src/useCases/mcaWritingStyleFormatter.test.tsx
+++ b/src/useCases/mcaWritingStyleFormatter.test.tsx
@@ -176,6 +176,7 @@ describe("formatOwners()", () => {
 describe("formatFieldValue()", () => {
   const expectations = [
     { in: undefined, out: <i>{Placeholders.NoData}</i> },
+    { in: "", out: <i>{Placeholders.NoData}</i> },
     { in: "Beacons", out: <b>BEACONS</b> },
     { in: "1234", out: <b>1234</b> },
   ];
@@ -192,5 +193,9 @@ describe("formatFieldValue()", () => {
     expect(
       formatFieldValue("2021-05-06T10:00:04.285653", FieldValueTypes.DATE)
     ).toEqual(<b>May 2021</b>);
+  });
+
+  it(`formats ${FieldValueTypes.MULTILINE} values correctly i.e. will not show ${Placeholders.NoData} if value is missing`, () => {
+    expect(formatFieldValue("", FieldValueTypes.MULTILINE)).toEqual(<></>);
   });
 });

--- a/src/useCases/mcaWritingStyleFormatter.tsx
+++ b/src/useCases/mcaWritingStyleFormatter.tsx
@@ -54,15 +54,15 @@ export const formatFieldValue = (
   value: string | undefined,
   valueType?: FieldValueTypes
 ): JSX.Element => {
-  switch (typeof value) {
-    case "undefined":
+  if (value) {
+    if (valueType === FieldValueTypes.DATE) {
+      return <b>{formatDateShort(value)}</b>;
+    } else {
+      return <b>{value.toLocaleUpperCase()}</b>;
+    }
+  } else {
+    if (valueType !== FieldValueTypes.MULTILINE)
       return <i>{Placeholders.NoData}</i>;
-    case "string":
-      console.log(value, valueType);
-      if (valueType === FieldValueTypes.DATE) {
-        return <b>{formatDateShort(value)}</b>;
-      } else {
-        return <b>{value.toLocaleUpperCase()}</b>;
-      }
+    return <></>;
   }
 };

--- a/src/useCases/mcaWritingStyleFormatter.tsx
+++ b/src/useCases/mcaWritingStyleFormatter.tsx
@@ -1,3 +1,4 @@
+import { FieldValueTypes } from "../components/dataPanel/FieldValue";
 import { IEmergencyContact } from "../entities/IEmergencyContact";
 import { IOwner } from "../entities/IOwner";
 import { IUse } from "../entities/IUse";
@@ -10,10 +11,16 @@ export enum Placeholders {
   NoData = "NO DATA ENTERED",
 }
 
-export const formatDate = (dateString: string): string => {
+export const formatDateLong = (dateString: string): string => {
   const date = new Date(dateString);
   const [, month, day, year] = date.toDateString().split(" ");
   return `${parseInt(day)} ${month} ${year.slice(2)}`;
+};
+
+export const formatDateShort = (dateString: string): string => {
+  const date = new Date(dateString);
+  const [, month, , year] = date.toDateString().split(" ");
+  return `${month} ${year}`;
 };
 
 export const formatUses = (uses: IUse[]): string =>
@@ -43,11 +50,19 @@ export const formatEmergencyContacts = (
   emergencyContacts: IEmergencyContact[]
 ): string => `${emergencyContacts.length} listed`;
 
-export const formatFieldValue = (value: string | undefined): JSX.Element => {
+export const formatFieldValue = (
+  value: string | undefined,
+  valueType?: FieldValueTypes
+): JSX.Element => {
   switch (typeof value) {
     case "undefined":
       return <i>{Placeholders.NoData}</i>;
     case "string":
-      return <b>{value.toLocaleUpperCase()}</b>;
+      console.log(value, valueType);
+      if (valueType === FieldValueTypes.DATE) {
+        return <b>{formatDateShort(value)}</b>;
+      } else {
+        return <b>{value.toLocaleUpperCase()}</b>;
+      }
   }
 };


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
Matching wireframes a bit more closely mainly:
- Make dates more readable and not a ISO timestamp
- Show `NO DATA ENTERED` where relevant
 
<img height=300 src="https://user-images.githubusercontent.com/32230328/117434164-3bafea00-af24-11eb-945d-260cee5d42c1.png"></img> ➡️ <img height=300 src="https://user-images.githubusercontent.com/32230328/117426925-60a05f00-af1c-11eb-990e-75a3026de06b.png"></img>

## Changes in this pull request

<!-- List all the changes, if there are UI changes, please include Before and After screenshots.  -->

- Get `FieldValue` to take a `valueType` (enum) to know how to format the value

## Link to Trello card

<!-- https://trello.com/b/p2XQo8jN/beacons-beta-private -->
https://trello.com/c/UE1iZx0n/513-view-beacon-record-readonly
