### PR TITLE
Turn off caching of static content

### DIFF
--- a/terraform/cloudfront.tf
+++ b/terraform/cloudfront.tf
@@ -28,8 +28,8 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
 
     viewer_protocol_policy = "redirect-to-https"
     min_ttl                = 0
-    default_ttl            = 3600  // 1 hour
-    max_ttl                = 86400 // 1 day
+    default_ttl            = 0
+    max_ttl                = 0
   }
 
   price_class = "PriceClass_100" // Least expensive option, caches in North America and Europe


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

We're using CloudFront to serve static assets from S3 using HTTPS.  We started off following the Terraform example for a CloudFront resource, which set the default TTL to 1 hour.

A TTL of 1 hour has posed issues for getting tickets signed off, as we've had to manually invalidate CloudFront or worse, wait an hour before asking for PO sign-off.

As we do not need caching at the current stage of development, this PR turns off caching by setting themin/max/default TTLs to 0.  HTTPS is unaffected. 

## Changes in this pull request

<!-- List all the changes, if there are UI changes, please include Before and After screenshots.  -->

- Set min_ttl, default_ttl and max_ttl all to 0.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

Check out https://stackoverflow.com/questions/10621099/what-is-a-ttl-0-in-CloudFront-useful-for for further info.

## Link to Trello card

<!-- https://trello.com/b/p2XQo8jN/beacons-beta-private -->

## Things to check

- [ ] Environment variables have been updated