### PR TITLE
Ux updates

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,6 @@ import {
 } from "react-router-dom";
 import "./App.scss";
 import { AuthWrapper } from "./components/auth/AuthWrapper";
-import { Home } from "./components/Home";
 import { Footer } from "./components/layout/Footer";
 import { Navigation } from "./components/layout/Navigation";
 import { applicationConfig } from "./config";
@@ -63,9 +62,6 @@ const App: FunctionComponent = () => {
         <RequireAuth>
           <Switch>
             <Route exact path="/">
-              <Home />
-            </Route>
-            <Route path="/beacon-records">
               <BeaconRecordsListView beaconsGateway={beaconsGateway} />
             </Route>
             <Route path="/beacons/:id">

--- a/src/components/layout/Navigation.tsx
+++ b/src/components/layout/Navigation.tsx
@@ -27,9 +27,6 @@ export const Navigation: FunctionComponent = (): JSX.Element => {
       <AppBar position="static">
         <Toolbar>
           <Button color="inherit" href="/">
-            Overview
-          </Button>
-          <Button color="inherit" href="/#/beacon-records">
             Beacon records
           </Button>
           <Box ml="auto">

--- a/src/panels/ownerPanel/OwnerPanel.test.tsx
+++ b/src/panels/ownerPanel/OwnerPanel.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen, waitFor } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
 import { beaconFixture } from "fixtures/beacons.fixture";
 import { IBeaconsGateway } from "../../gateways/IBeaconsGateway";
 import { Placeholders } from "../../utils/writingStyle";
@@ -67,25 +66,5 @@ describe("Owner Summary Panel", () => {
     expect(
       await screen.findByText(Placeholders.UnspecifiedError)
     ).toBeVisible();
-  });
-
-  it("fetches beacon data on state change", async () => {
-    render(
-      <OwnerPanel
-        beaconsGateway={beaconsGatewayDouble}
-        beaconId={beaconFixture.id}
-      />
-    );
-    expect(beaconsGatewayDouble.getBeacon).toHaveBeenCalledTimes(1);
-
-    const editButton = await screen.findByText(/edit owner/i);
-    userEvent.click(editButton);
-    expect(beaconsGatewayDouble.getBeacon).toHaveBeenCalledTimes(2);
-
-    const cancelButton = await screen.findByRole("button", {
-      name: "Cancel",
-    });
-    userEvent.click(cancelButton);
-    expect(beaconsGatewayDouble.getBeacon).toHaveBeenCalledTimes(3);
   });
 });

--- a/src/panels/ownerPanel/OwnerPanel.tsx
+++ b/src/panels/ownerPanel/OwnerPanel.tsx
@@ -1,11 +1,9 @@
 import { Card, CardContent, CardHeader } from "@material-ui/core";
 import { FunctionComponent, useEffect, useState } from "react";
-import { EditPanelButton } from "../../components/dataPanel/EditPanelButton";
 import { FieldValueTypes } from "../../components/dataPanel/FieldValue";
 import { ErrorState } from "../../components/dataPanel/PanelErrorState";
 import { LoadingState } from "../../components/dataPanel/PanelLoadingState";
 import { PanelViewingState } from "../../components/dataPanel/PanelViewingState";
-import { DataPanelStates } from "../../components/dataPanel/States";
 import { IOwner } from "../../entities/IOwner";
 import { IBeaconsGateway } from "../../gateways/IBeaconsGateway";
 import { Placeholders } from "../../utils/writingStyle";
@@ -20,9 +18,6 @@ export const OwnerPanel: FunctionComponent<OwnerSummaryPanelProps> = ({
   beaconId,
 }) => {
   const [owner, setOwner] = useState<IOwner>();
-  const [userState, setUserState] = useState<DataPanelStates>(
-    DataPanelStates.Viewing
-  );
   const [error, setError] = useState(false);
   const [loading, setLoading] = useState(true);
 
@@ -40,7 +35,7 @@ export const OwnerPanel: FunctionComponent<OwnerSummaryPanelProps> = ({
     };
 
     fetchBeacon(beaconId);
-  }, [userState, beaconId, beaconsGateway]);
+  }, [beaconId, beaconsGateway]);
 
   const fields = [
     { key: "Name", value: owner?.fullName },
@@ -59,33 +54,6 @@ export const OwnerPanel: FunctionComponent<OwnerSummaryPanelProps> = ({
     },
   ];
 
-  const renderState = () => {
-    switch (userState) {
-      case DataPanelStates.Viewing:
-        return (
-          <>
-            <EditPanelButton
-              onClick={() => setUserState(DataPanelStates.Editing)}
-            >
-              Edit owner
-            </EditPanelButton>
-            <PanelViewingState fields={fields} />
-          </>
-        );
-      case DataPanelStates.Editing:
-        return (
-          <>
-            <p>TODO</p>
-            <button onClick={() => setUserState(DataPanelStates.Viewing)}>
-              Cancel
-            </button>
-          </>
-        );
-      default:
-        setError(true);
-    }
-  };
-
   return (
     <Card>
       <CardContent>
@@ -93,7 +61,7 @@ export const OwnerPanel: FunctionComponent<OwnerSummaryPanelProps> = ({
         <>
           {error && <ErrorState message={Placeholders.UnspecifiedError} />}
           {loading && <LoadingState />}
-          {error || loading || renderState()}
+          {error || loading || <PanelViewingState fields={fields} />}
         </>
       </CardContent>
     </Card>


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

UX updates made with Ant today and yesterday.

## Changes in this pull request

<!-- List all the changes, if there are UI changes, please include Before and After screenshots.  -->

- Remove edit state (and button) from Owner panel.
- Set the all beacons table to be the default view, removing the Overview view.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

New default view at root:
![image](https://user-images.githubusercontent.com/54271433/119003449-a5e57780-b985-11eb-9f7e-9ba560aea635.png)

Owner panel with Edit button removed:
![image](https://user-images.githubusercontent.com/54271433/119003508-af6edf80-b985-11eb-9d6c-e59f541cb474.png)

## Link to Trello card

<!-- https://trello.com/b/p2XQo8jN/beacons-beta-private -->

## Things to check

- [ ] Environment variables have been updated