### PR TITLE
Making fetch happen... for notes

### DIFF
--- a/src/entities/INote.ts
+++ b/src/entities/INote.ts
@@ -1,0 +1,9 @@
+export interface INote {
+  id: string;
+  beaconId: string;
+  text: string;
+  type: string;
+  userId: string;
+  fullName: string;
+  email: string;
+}

--- a/src/fixtures/notes.fixture.ts
+++ b/src/fixtures/notes.fixture.ts
@@ -1,0 +1,23 @@
+import { INote } from "../entities/INote";
+import { deepFreeze } from "../utils";
+
+export const notesFixture = deepFreeze<INote[]>([
+  {
+    id: "bc6d7716-f8cd-469e-a701-10cac3775eb5",
+    beaconId: "8b0c56-77d3-42da-8d0a-48f987eeac4c",
+    text: "That's a great beacon right there",
+    type: "GENERAL",
+    userId: "344848b9-8a5d-4818-a57d-1815528d543e",
+    fullName: "Jean ValJean",
+    email: "24601@jail.fr",
+  },
+  {
+    id: "0f2b0eec-9e10-4a98-bd28-57cf2aab85e0",
+    beaconId: "8b0c56-77d3-42da-8d0a-48f987eeac4c",
+    text: "That's a great beacon right there",
+    type: "GENERAL",
+    userId: "344848b9-8a5d-4818-a57d-1815528d543e",
+    fullName: "Jean ValJean",
+    email: "24601@jail.fr",
+  },
+]);

--- a/src/fixtures/notesResponse.fixture.ts
+++ b/src/fixtures/notesResponse.fixture.ts
@@ -1,0 +1,37 @@
+import { INotesResponse } from "../gateways/mappers/INotesResponse";
+import { deepFreeze } from "../utils";
+
+export const notesResponseFixture = deepFreeze<INotesResponse>({
+  meta: {
+    count: 2,
+  },
+  data: [
+    {
+      type: "note",
+      id: "bc6d7716-f8cd-469e-a701-10cac3775eb5",
+      attributes: {
+        beaconId: "8b0c56-77d3-42da-8d0a-48f987eeac4c",
+        text: "That's a great beacon right there",
+        type: "GENERAL",
+        userId: "344848b9-8a5d-4818-a57d-1815528d543e",
+        fullName: "Jean ValJean",
+        email: "24601@jail.fr",
+      },
+      relationships: {},
+    },
+    {
+      type: "note",
+      id: "0f2b0eec-9e10-4a98-bd28-57cf2aab85e0",
+      attributes: {
+        beaconId: "8b0c56-77d3-42da-8d0a-48f987eeac4c",
+        text: "That's a great beacon right there",
+        type: "GENERAL",
+        userId: "344848b9-8a5d-4818-a57d-1815528d543e",
+        fullName: "Jean ValJean",
+        email: "24601@jail.fr",
+      },
+      relationships: {},
+    },
+  ],
+  included: [],
+});

--- a/src/gateways/mappers/INotesResponse.ts
+++ b/src/gateways/mappers/INotesResponse.ts
@@ -1,0 +1,17 @@
+import { IApiResponse } from "./IApiResponse";
+
+export interface INotesResponse extends IApiResponse {
+  data: {
+    type: string;
+    id: string;
+    attributes: {
+      beaconId: string;
+      text: string;
+      type: string;
+      userId: string;
+      fullName: string;
+      email: string;
+    };
+    relationships: Record<string, any>;
+  }[];
+}

--- a/src/gateways/mappers/NotesResponseMapper.ts
+++ b/src/gateways/mappers/NotesResponseMapper.ts
@@ -1,0 +1,28 @@
+import { INote } from "../../entities/INote";
+import { INotesResponse } from "./INotesResponse";
+
+export interface INotesResponseMapper {
+  map: (notesResponse: INotesResponse) => INote[];
+}
+
+export class NotesResponseMapper implements INotesResponseMapper {
+  public map(notesResponse: INotesResponse): INote[] {
+    const notes: INote[] = [];
+
+    if (!notesResponse.data || notesResponse.data.length === 0) return [];
+
+    notesResponse.data.forEach((noteResponse) => {
+      notes.push({
+        id: noteResponse.id,
+        beaconId: noteResponse.attributes.beaconId,
+        text: noteResponse.attributes.text,
+        type: noteResponse.attributes.type,
+        userId: noteResponse.attributes.userId,
+        fullName: noteResponse.attributes.fullName,
+        email: noteResponse.attributes.email,
+      });
+    });
+
+    return notes;
+  }
+}

--- a/src/gateways/notes/INotesGateway.ts
+++ b/src/gateways/notes/INotesGateway.ts
@@ -1,0 +1,5 @@
+import { INote } from "../../entities/INote";
+
+export interface INotesGateway {
+  getNotes: (beaconId: string) => Promise<INote[]>;
+}

--- a/src/gateways/notes/NotesGateway.test.ts
+++ b/src/gateways/notes/NotesGateway.test.ts
@@ -1,0 +1,67 @@
+import axios from "axios";
+import { applicationConfig } from "../../config";
+import { notesFixture } from "../../fixtures/notes.fixture";
+import { notesResponseFixture } from "../../fixtures/notesResponse.fixture";
+import { IAuthGateway } from "../auth/IAuthGateway";
+import {
+  INotesResponseMapper,
+  NotesResponseMapper,
+} from "../mappers/NotesResponseMapper";
+import { INotesGateway } from "./INotesGateway";
+import { NotesGateway } from "./NotesGateway";
+
+jest.mock("axios");
+describe("NotesGateway", () => {
+  let gateway: INotesGateway;
+  let beaconId: string;
+  let notesResponseMapper: INotesResponseMapper;
+  let authGateway: IAuthGateway;
+  let accessToken: string;
+  let config: any;
+
+  beforeEach(() => {
+    notesResponseMapper = new NotesResponseMapper();
+    accessToken = "knock knock";
+    authGateway = {
+      getAccessToken: jest.fn().mockResolvedValue(accessToken),
+    };
+    gateway = new NotesGateway(notesResponseMapper, authGateway);
+    beaconId = "de8b0c56-77d3-42da-8d0a-48f987eeac4c";
+    config = {
+      timeout: applicationConfig.apiTimeoutMs,
+      headers: { Authorization: `Bearer ${accessToken}` },
+    };
+  });
+
+  describe("NotesGateway", () => {
+    it.only("queries the correct endpoint", async () => {
+      // @ts-ignore
+      axios.get.mockImplementationOnce(() => Promise.resolve({ data: {} }));
+
+      await gateway.getNotes(beaconId);
+
+      expect(axios.get).toHaveBeenCalledWith(
+        `${applicationConfig.apiUrl}/beacons/${beaconId}/notes`,
+        config
+      );
+    });
+
+    it("maps and returns a list of notes", async () => {
+      // @ts-ignore
+      axios.get.mockImplementationOnce(() =>
+        Promise.resolve({ data: notesResponseFixture })
+      );
+
+      const notes = await gateway.getNotes(beaconId);
+
+      expect(notes).toStrictEqual(notesFixture);
+    });
+
+    it("throws errors", async () => {
+      // @ts-ignore
+      axios.get.mockImplementationOnce(() => Promise.reject(new Error()));
+
+      await expect(gateway.getNotes(beaconId)).rejects.toThrow();
+    });
+  });
+});

--- a/src/gateways/notes/NotesGateway.test.ts
+++ b/src/gateways/notes/NotesGateway.test.ts
@@ -34,7 +34,7 @@ describe("NotesGateway", () => {
   });
 
   describe("NotesGateway", () => {
-    it.only("queries the correct endpoint", async () => {
+    it("queries the correct endpoint", async () => {
       // @ts-ignore
       axios.get.mockImplementationOnce(() => Promise.resolve({ data: {} }));
 

--- a/src/gateways/notes/NotesGateway.ts
+++ b/src/gateways/notes/NotesGateway.ts
@@ -1,0 +1,37 @@
+import axios, { AxiosResponse } from "axios";
+import { applicationConfig } from "../../config";
+import { INote } from "../../entities/INote";
+import { IAuthGateway } from "../auth/IAuthGateway";
+import { INotesResponseMapper } from "../mappers/NotesResponseMapper";
+import { INotesGateway } from "./INotesGateway";
+
+export class NotesGateway implements INotesGateway {
+  private _notesResponseMapper: INotesResponseMapper;
+  private _authGateway: IAuthGateway;
+
+  public constructor(
+    notesResponseMapper: INotesResponseMapper,
+    authGateway: IAuthGateway
+  ) {
+    this._notesResponseMapper = notesResponseMapper;
+    this._authGateway = authGateway;
+  }
+
+  public async getNotes(beaconId: string): Promise<INote[]> {
+    try {
+      const response = await this._makeGetRequest(`/beacons/${beaconId}/notes`);
+      return this._notesResponseMapper.map(response.data);
+    } catch (e) {
+      throw Error(e);
+    }
+  }
+
+  private async _makeGetRequest(path: string): Promise<AxiosResponse> {
+    const accessToken = await this._authGateway.getAccessToken();
+
+    return await axios.get(`${applicationConfig.apiUrl}${path}`, {
+      timeout: applicationConfig.apiTimeoutMs,
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+  }
+}

--- a/src/panels/ownerPanel/OwnerPanel.test.tsx
+++ b/src/panels/ownerPanel/OwnerPanel.test.tsx
@@ -12,6 +12,7 @@ describe("Owner Summary Panel", () => {
       getBeacon: jest.fn().mockResolvedValue(beaconFixture),
       getAllBeacons: jest.fn(),
       updateBeacon: jest.fn(),
+      getLegacyBeacon: jest.fn(),
     };
   });
 


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
<img width=400 src="https://media.giphy.com/media/3otPoUjeyRisIDxPhK/giphy.gif?cid=ecf05e47ja51jz5i265zy5dxqqdjt5ui88p4oy63numctyrq&rid=giphy.gif&ct=g"></img>

Backoffice users need to be able to view and add notes to non-legacy Beacons - this is the first step towards that.

## Changes in this pull request

<!-- List all the changes, if there are UI changes, please include Before and After screenshots.  -->
Added:
- Note entity
- NotesGateway
- NotesMapper - takes a Notes API response and maps it into Notes
- Tests
- Fixtures for tests

## Link to Trello card

<!-- https://trello.com/b/p2XQo8jN/beacons-beta-private -->
Small slice 🍰  of https://trello.com/c/ifhYzXqT/676-back-office-users-need-ability-to-add-notes-to-a-beacon-record