### PR TITLE
Claimed legacy beacons show up as deleted in table

### DIFF
--- a/src/components/BeaconsTable.tsx
+++ b/src/components/BeaconsTable.tsx
@@ -33,6 +33,7 @@ interface BeaconTableListRow {
   id: string;
   lastModifiedDate: string;
   beaconStatus: string;
+  beaconType: "BEACON" | "LEGACY_BEACON";
 }
 
 export const BeaconsTable: FunctionComponent<IBeaconsTableProps> = ({
@@ -95,7 +96,7 @@ export const BeaconsTable: FunctionComponent<IBeaconsTableProps> = ({
           field: "hexId",
           filtering: false,
           render: (rowData: BeaconTableListRow) => {
-            if (rowData.beaconStatus === "MIGRATED") {
+            if (rowData.beaconType === "LEGACY_BEACON") {
               return (
                 <Link href={"/#/legacy-beacons/" + rowData.id}>
                   {rowData.hexId ? rowData.hexId : <i>{Placeholders.NoData}</i>}
@@ -164,6 +165,7 @@ export const BeaconsTable: FunctionComponent<IBeaconsTableProps> = ({
                 ownerName: item.ownerName,
                 useActivities: item.useActivities,
                 id: item.id,
+                beaconType: item.beaconType,
               })
             );
             resolve({

--- a/src/entities/IBeaconSearchResult.ts
+++ b/src/entities/IBeaconSearchResult.ts
@@ -16,6 +16,7 @@ export interface IBeaconSearchResultData {
   hexId: string;
   ownerName: string;
   useActivities: string;
+  beaconType: "BEACON" | "LEGACY_BEACON";
   _links: {
     self: {
       href: string;

--- a/src/fixtures/beaconSearchResult.fixture.ts
+++ b/src/fixtures/beaconSearchResult.fixture.ts
@@ -17,6 +17,7 @@ export const beaconSearchResultFixture = deepFreeze<IBeaconSearchResult>({
         lastModifiedDate: "2020-02-01T00:00",
         useActivities: "SAILING, KAYAKING",
         ownerName: "Vice-Admiral Horatio Nelson, 1st Viscount Nelson",
+        beaconType: "BEACON",
         _links: {
           self: {
             href: "/97b306aa-cbd0-4f09-aa24-2d876b983efb",
@@ -33,6 +34,7 @@ export const beaconSearchResultFixture = deepFreeze<IBeaconSearchResult>({
         lastModifiedDate: "2020-02-01T00:00",
         useActivities: "MOTORING",
         ownerName: "Vice-Admiral Horatio Nelson, 1st Viscount Nelson",
+        beaconType: "BEACON",
         _links: {
           self: {
             href: "/97b306aa-cbd0-4f09-aa24-2d876b983efc",
@@ -49,6 +51,7 @@ export const beaconSearchResultFixture = deepFreeze<IBeaconSearchResult>({
         lastModifiedDate: "2020-02-01T00:00",
         useActivities: "VESSELING",
         ownerName: "Vice-Admiral Horatio Nelson, 1st Viscount Nelson",
+        beaconType: "BEACON",
         _links: {
           self: {
             href: "/97b306aa-cbd0-4f09-aa24-2d876b983efd",


### PR DESCRIPTION
Use `beaconType` returned from API to redirect to correct beacon view when clicking on a beacon in the table.